### PR TITLE
aspida:build スクリプトの修正

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "yarn g:lint",
     "format": "yarn g:format",
-    "aspida:build": "aspida",
+    "api:build": "../../node_modules/.bin/aspida",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
よく分からないが `yarn aspida` で↓になるようになってしまったので、直接 ../../node_modules/.bin/aspida を叩くようにとりあえず修正。
```
Usage Error: Couldn't find a script named "aspida"
```