### PR TITLE
fix: awaitable typing

### DIFF
--- a/apps/web/src/hooks/useLocalLoading.ts
+++ b/apps/web/src/hooks/useLocalLoading.ts
@@ -1,9 +1,10 @@
 import { useCallback, useState } from 'react';
+import type { Awaitable } from '@/types/utils';
 
 export const useLocalLoading = <T>(): [boolean, (cb: () => T | Promise<T>) => Promise<T>] => {
   const [isLoading, setIsLoading] = useState(false);
 
-  const load = useCallback(async (cb: () => T | Promise<T>) => {
+  const load = useCallback(async (cb: () => Awaitable<T>) => {
     setIsLoading(true);
     const result = await cb();
     setIsLoading(false);

--- a/apps/web/src/types/utils.ts
+++ b/apps/web/src/types/utils.ts
@@ -1,0 +1,1 @@
+export type Awaitable<T> = T | PromiseLike<T>;


### PR DESCRIPTION
next-auth の Awaitable が良かったので、変更。
PrismaPromise とかも一貫して扱えそうなので。

`useLocalLoading` の `cb` は、prisma は関わらないんですが `Awaitable` という意味合いの型なのでこれに更新。